### PR TITLE
Allow staff/superusers to create loans on behalf of another person

### DIFF
--- a/src/lgr/views.py
+++ b/src/lgr/views.py
@@ -36,7 +36,12 @@ def auth(request):
             return JsonResponse(response, status=400)
 
     if request.user and request.user.is_authenticated:
-        response = {"logged_in": True, "username": request.user.username}
+        response = {
+            "logged_in": True,
+            "username": request.user.username,
+            "is_staff": request.user.is_staff,
+            "is_superuser": request.user.is_superuser,
+        }
         return JsonResponse(response)
 
     response = {"logged_in": False, "username": ""}
@@ -106,7 +111,12 @@ def loan(request):
         return JsonResponse(response, status=400)
 
     # valid loan
+    # Privileged users (staff/superuser) may loan on behalf of another person by passing
+    # "person" (a Person id) in the payload; everyone else loans for themselves.
     person = models.Person.objects.get(nickname=request.user.username)
+    requested_person = payload.get("person")
+    if requested_person and (request.user.is_staff or request.user.is_superuser):
+        person = models.Person.objects.get(pk=requested_person)
     _loan = models.Loan.objects.create(person=person, return_date=return_date)
     _loan.barcodes.set(items.all())
     response = {"message": "Loan for %s items created." % _loan.barcodes.count()}


### PR DESCRIPTION
## What

Two small, related changes to `views.py`:

1. **`auth()`** now includes `is_staff` and `is_superuser` in the logged-in response payload, so the frontend can tell whether the current user has elevated rights.
2. **`loan()`** allows a staff member or superuser to create a loan **on behalf of another person** by passing a `person` (a `Person` id) in the request payload. Unprivileged users are unaffected and continue to loan for themselves only.

## Why

Enables trusted users (e.g. at a desk/terminal) to record loans for others without each person needing to authenticate, while keeping the default behaviour locked down for everyone else.

## Notes

- The privilege check (`request.user.is_staff or request.user.is_superuser`) gates the behalf-of path; absent the `person` key or the privilege, behaviour is unchanged.