### PR TITLE
Autocomplete parent field in barcode inline admin

### DIFF
--- a/src/lgr/admin.py
+++ b/src/lgr/admin.py
@@ -310,7 +310,7 @@ class BarcodeAdmin(admin.ModelAdmin):
 
 class BarcodeInline(admin.TabularInline):
     model = models.Barcode
-    autocomplete_fields = ("owner",)
+    autocomplete_fields = ("owner", "parent")
 
     def get_formset(self, request, obj, **kwargs):
         formset = super().get_formset(request, obj, **kwargs)


### PR DESCRIPTION
## What

Add `parent` to `BarcodeInline.autocomplete_fields` in the admin.

## Why

When editing nested barcodes inline, the `parent` field was rendered as a plain select listing every barcode. This makes it a searchable autocomplete widget, consistent with how `parent` is already handled in the standalone `BarcodeAdmin`.